### PR TITLE
Trivial fixes

### DIFF
--- a/tools/bibtex2lose.scm
+++ b/tools/bibtex2lose.scm
@@ -1,5 +1,10 @@
 #! /usr/bin/env gosh
 
+;;;; Script to convert BibTeX bibliography to losebib
+
+;;; Copyright 2020-2021 Lassi Kortela
+;;; SPDX-License-Identifier: MIT
+
 (import (scheme base) (scheme write) (gauche base) (srfi 1) (srfi 13))
 
 (define (read-all-lines)

--- a/tools/bibtex2lose.scm
+++ b/tools/bibtex2lose.scm
@@ -1,5 +1,7 @@
-#! /usr/bin/env gosh
-
+#!/bin/sh
+#|
+exec gosh -I$(dirname $0) -- $0 "$@"
+|#
 ;;;; Script to convert BibTeX bibliography to losebib
 
 ;;; Copyright 2020-2021 Lassi Kortela

--- a/tools/losebib-read.sld
+++ b/tools/losebib-read.sld
@@ -1,3 +1,8 @@
+;;;; Library for reading losebib files
+
+;;; Copyright 2020 Lassi Kortela
+;;; SPDX-License-Identifier: MIT
+
 (define-library (losebib-read)
   (export losebib-read-all losebib-read-file)
   (import (scheme base) (scheme file) (scheme read))

--- a/tools/losebib2json.scm
+++ b/tools/losebib2json.scm
@@ -1,5 +1,10 @@
 #! /usr/bin/env gosh
 
+;;;; Script to convert losebib file to JSON
+
+;;; Copyright 2020 Lassi Kortela
+;;; SPDX-License-Identifier: MIT
+
 (import (scheme base) (scheme write) (srfi 1))
 (import (rfc json))
 (import (losebib-read))

--- a/tools/losebib2json.scm
+++ b/tools/losebib2json.scm
@@ -1,5 +1,7 @@
-#! /usr/bin/env gosh
-
+#!/bin/sh
+#|
+exec gosh -I$(dirname $0) -- $0 "$@"
+|#
 ;;;; Script to convert losebib file to JSON
 
 ;;; Copyright 2020 Lassi Kortela

--- a/tools/losebib2markdown.scm
+++ b/tools/losebib2markdown.scm
@@ -1,5 +1,10 @@
 #!
 
+;;;; Script to convert losebib files to Markdown
+
+;;; Copyright 2020 Lassi Kortela
+;;; SPDX-License-Identifier: MIT
+
 (import (scheme base) (scheme write))
 (import (losebib-read))
 

--- a/tools/losebib2markdown.scm
+++ b/tools/losebib2markdown.scm
@@ -1,5 +1,7 @@
-#!
-
+#!/bin/sh
+#|
+exec gosh -I$(dirname $0) -- $0 "$@"
+|#
 ;;;; Script to convert losebib files to Markdown
 
 ;;; Copyright 2020 Lassi Kortela

--- a/tools/scheme-bibliography.el
+++ b/tools/scheme-bibliography.el
@@ -1,3 +1,8 @@
+;;;; Support macros for working on Scheme Bibliography
+
+;;; Copyright 2020 Lassi Kortela
+;;; SPDX-License-Identifier: MIT
+
 (defvar scheme-bibliography-pdf-todo-directory nil)
 (defvar scheme-bibliography-pdf-directory nil)
 


### PR DESCRIPTION
Add `-I` to fix load errors and clarify that scripts are released under the MIT License.

See also: https://github.com/schemedoc/bibliography/issues/7