### PR TITLE
Document BibTeX name parsing rules

### DIFF
--- a/FORMAT.md
+++ b/FORMAT.md
@@ -26,3 +26,17 @@ The overview of format is:
     [(id ...) ...]
 
     (end-group)
+
+## Name Formats
+
+If the `<name>` in `(author <name>)` or `(editor <name>)` is a string,
+its interpretation is unspecified.
+
+If the `<name>` is `(bibtex <given> <particle> <family> <suffix>)`
+where `<given>`, `<particle>`, `<family>` and `<suffix>` are strings,
+it is interpreted as a *BibTeX-modeled name.*
+
+In the BibTeX-modeled names, `<given>`, `<particle>` and `<suffix>` can be
+zero-length strings.
+
+It is an error if the `<name>` is neither of the above.


### PR DESCRIPTION
Indeed [structured name field sucks](https://docs.google.com/document/d/1Of_rL8gMtHcfPaE5DfZ1xahrOtOaxFEHiQkcxvvR3lY/edit) and [what we assume about names are false](https://www.kalzumeus.com/2010/06/17/falsehoods-programmers-believe-about-names/) but we have to deal with major bibliography software assuming (a subset of) European name structure.

Leave complex cases described in the [TeX FAQ](https://texfaq.org/FAQ-bibprefixsort), a [thread at comp.text.tex](https://groups.google.com/g/comp.text.tex/c/pQCPH3fwGSE), [tips by Norman Walsh](https://nwalsh.com/tex/texhelp/bibtx-23.html), questions on Stack Exchange and such for now.